### PR TITLE
chore: update expo-sqlite to v16 for Expo SDK 52 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist/"
-  ],
+  "files": ["dist/"],
   "license": "MIT",
   "keywords": [
     "kysely",
@@ -25,11 +23,11 @@
     "query builder"
   ],
   "peerDependencies": {
-    "expo-sqlite": "^15.2.10",
+    "expo-sqlite": "^16.0.8",
     "kysely": "^0.28.2"
   },
   "dependencies": {
-    "expo-sqlite": "^15.2.10",
+    "expo-sqlite": "^16.0.8",
     "kysely": "^0.28.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- Update expo-sqlite peer dependency from ^15.1.2 to ^16.0.8
- Update kysely peer dependency from ^0.27.6 to ^0.28.2
